### PR TITLE
Aspell lib expects the bytesize of the word

### DIFF
--- a/lib/ffi/aspell/speller.rb
+++ b/lib/ffi/aspell/speller.rb
@@ -118,7 +118,7 @@ module FFI
         end
 
         speller = Aspell.speller_new(@config)
-        correct = Aspell.speller_check(speller, word.to_s, word.length)
+        correct = Aspell.speller_check(speller, word.to_s, word.bytesize)
 
         Aspell.speller_delete(speller)
 
@@ -139,7 +139,7 @@ module FFI
         end
 
         speller     = Aspell.speller_new(@config)
-        list        = Aspell.speller_suggest(speller, word, word.length)
+        list        = Aspell.speller_suggest(speller, word, word.bytesize)
         suggestions = []
         elements    = Aspell.word_list_elements(list)
 

--- a/spec/ffi/aspell/speller.rb
+++ b/spec/ffi/aspell/speller.rb
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 require File.expand_path('../../../helper', __FILE__)
 
 describe 'FFI::Aspell::Speller' do
@@ -58,6 +60,13 @@ describe 'FFI::Aspell::Speller' do
     speller.correct?('koekje').should == true
     speller.correct?('werld').should  == false
     speller.correct?('huis').should   == true
+  end
+
+  it 'Validate some UTF-8 (Greek) words' do
+    speller = FFI::Aspell::Speller.new('el')
+
+    speller.correct?('χταπόδι').should == true
+    speller.correct?('οιρανός').should  == false
   end
 
   it 'Change the language of an existing speller object' do


### PR DESCRIPTION
Fixes bug with strings containing multibyte
characters (for example, all languages using non ascii part
of UTF-8).

Ref: http://aspell.net/0.50-doc/man-html/6_Writing.html

Tests need aspell-el. I don't speak any Dutch so i used some greek words for multibyte testing
If there are any Dutch words using multibyte characters, could you replace mine to eliminate 
the extra dependency for the tests?
