### PR TITLE
Add alternate library name for Ubuntu 14.04.

### DIFF
--- a/lib/ffi/aspell/aspell.rb
+++ b/lib/ffi/aspell/aspell.rb
@@ -14,7 +14,7 @@ module FFI
   #
   module Aspell
     extend   FFI::Library
-    ffi_lib 'aspell'
+    ffi_lib ['aspell', 'libaspell.so.15']
 
     ##
     # Creates a pointer for a configuration struct.


### PR DESCRIPTION
Fixes #18.
No test was added because the existing tests already failed, and this
change makes them pass again.
