### PR TITLE
Add test for initialize method interface

### DIFF
--- a/lib/ffi/aspell/speller.rb
+++ b/lib/ffi/aspell/speller.rb
@@ -459,6 +459,7 @@ module FFI
           dict_info = Aspell::DictInfo.new(element)
 
           dicts << handle_output(dict_info[:code])
+          dicts << handle_output(dict_info[:code]).gsub("_", "-")
         end
 
         Aspell.delete_dict_info_enumeration(elements)

--- a/spec/ffi/aspell/speller_spec.rb
+++ b/spec/ffi/aspell/speller_spec.rb
@@ -29,6 +29,11 @@ describe FFI::Aspell::Speller do
 
       speller.get('lang').should == 'en'
     end
+
+    example 'initialize should accept _ and -' do
+      expect { described_class.new('en_GB') }.not_to raise_error
+      expect { described_class.new('en-GB') }.not_to raise_error
+    end
   end
 
   context '#close' do


### PR DESCRIPTION
Hi, we were using v1.0.1 of this gem and passing in 'en-GB' to `initialize`. In v1.0.2 this is broken, see test below.

I can see that you have added a check in `check_dictionary`. Perhaps this is too strict? I believe Aspell works both 'en-GB' and 'en_GB' 