### PR TITLE
Allows installation on Darwin

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Aspell can be installed as following:
 
 * Arch Linux: `sudo pacman -S aspell`
 * Ubuntu: `sudo apt-get install aspell libaspell-dev`
-* OS X: `brew install aspell --lang=en`
+* OS X: `brew install aspell --with-lang-en --with-lang-el --with-lang-nl`
 
 ## Usage
 

--- a/lib/ffi/aspell/aspell.rb
+++ b/lib/ffi/aspell/aspell.rb
@@ -1,3 +1,6 @@
+require 'open3'
+require 'rbconfig'
+
 module FFI
   ##
   # FFI::Aspell is an FFI binding for the Aspell spell checking library. Basic
@@ -13,8 +16,21 @@ module FFI
   # For more information see {FFI::Aspell::Speller}.
   #
   module Aspell
-    extend   FFI::Library
-    ffi_lib ['aspell', 'libaspell.so.15']
+    extend FFI::Library
+
+    begin
+      stdout, stderr, status = ::Open3.capture3("brew", "--prefix")
+      homebrew_path  = if status.success?
+                        "#{stdout.chomp}/lib"
+                      else
+                        '/usr/local/homebrew/lib'
+                      end
+    rescue
+      # Homebrew doesn't exist
+    end
+
+    ffi_lib ['aspell', 'libaspell.so.15'] if ::RbConfig::CONFIG['host_os'] =~ /linux/
+    ffi_lib ["#{homebrew_path}/libaspell.dylib"] if ::RbConfig::CONFIG['host_os'] =~ /darwin/
 
     ##
     # Structure for storing dictionary information.


### PR DESCRIPTION
* Previously would fail on OSX as it could not find the library:
```
/opt/boxen/rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/ffi-1.9.18/lib/ffi/library.rb:147:in `block in ffi_lib': Could not open library 'libaspell.dylib': dlopen(libaspell.dylib, 5): image not found (LoadError)
```
* Add logic to check for homebrew installation and load from the hombrew lib folder
* Might require further work for `macports` users
* Fixes #26