### PR TITLE
Adds spec for #reset

### DIFF
--- a/spec/ffi/aspell/speller_spec.rb
+++ b/spec/ffi/aspell/speller_spec.rb
@@ -277,6 +277,16 @@ describe FFI::Aspell::Speller do
       @speller = described_class.new
     end
 
+    it 'resets keys back to their default value' do
+      @speller.set('lang', 'nl')
+
+      expect(@speller.get('lang')).to eq('nl')
+
+      @speller.reset('lang')
+
+      expect(@speller.get('lang')).to eq('en_US')
+    end
+
     it 'raises RuntimeError if the speller is closed' do
       @speller.close
 


### PR DESCRIPTION
* Previously there was no test for update_speller
being run as part of a key reset:
```
+----------+---------------------------+-------+--------+-------------------+
| coverage | file                      | lines | missed | missing           |
+----------+---------------------------+-------+--------+-------------------+
|  96.33%  | lib/ffi/aspell/speller.rb | 109   | 4      | 141-142, 302, 369 |
+----------+---------------------------+-------+--------+-------------------+
```
* This adds a check to reset a key so that
`update_speller` gets called, and line `369` is
now covered! :dancer: