### PR TITLE
Fix pathing on osx plus ENV variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Aspell can be installed as following:
 
 * Arch Linux: `sudo pacman -S aspell`
 * Ubuntu: `sudo apt-get install aspell libaspell-dev`
-* OS X: `brew install aspell --lang=en`
+* OS X: `brew install aspell --with-lang-en --with-lang-el --with-lang-nl`
 
 The gem will attempt to look for the `libaspell` C library to bind to from your loadpath, for most people this will be automatic.
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Aspell can be installed as following:
 * Ubuntu: `sudo apt-get install aspell libaspell-dev`
 * OS X: `brew install aspell --lang=en`
 
+The gem will attempt to look for the `libaspell` C library to bind to from your loadpath, for most people this will be automatic.
+
+However, depending on your platform and package manager, you may want to specify a library path using the `ASPELL_LIB_PATH` environment variable:
+
+* `ASPELL_LIB_PATH='/opt/custom_homebrew/homebrew/lib/libaspell.dylib' bundle exec rake`
+
 ## Usage
 
 Install the gem:

--- a/lib/ffi/aspell/aspell.rb
+++ b/lib/ffi/aspell/aspell.rb
@@ -1,3 +1,5 @@
+require 'rbconfig'
+
 module FFI
   ##
   # FFI::Aspell is an FFI binding for the Aspell spell checking library. Basic
@@ -13,8 +15,23 @@ module FFI
   # For more information see {FFI::Aspell::Speller}.
   #
   module Aspell
-    extend   FFI::Library
-    ffi_lib ['aspell', 'libaspell.so.15']
+    extend FFI::Library
+
+    # Allow custom pathing to library path
+    if !!ENV['ASPELL_LIB_PATH']
+      ffi_lib ENV['ASPELL_LIB_PATH']
+    else
+      case ::RbConfig::CONFIG['host_os']
+      when /linux/
+        ffi_lib ['aspell', 'libaspell.so.15']
+      when /darwin/
+        if File.exist?('/opt/boxen/homebrew/lib/libaspell.dylib')
+          ffi_lib ['/opt/boxen/homebrew/lib/', 'libaspell.dylib']
+        elsif File.exist?('/usr/local/lib/libaspell.dylib')
+          ffi_lib ['/usr/local/homebrew/lib/', 'libaspell.dylib']
+        end
+      end
+    end
 
     ##
     # Structure for storing dictionary information.
@@ -257,10 +274,10 @@ module FFI
 
     ##
     # Gets a list of all installed aspell dictionaries.
-    # 
+    #
     # @method dict_info_list(config)
     # @scope  class
-    # @param  [FFI::Pointer] config 
+    # @param  [FFI::Pointer] config
     # @return [FFI::Pointer] list A list of dictionaries which can be used
     # by {FFI::Aspell.dict_info_list_elements}.
     #
@@ -271,12 +288,12 @@ module FFI
 
     ##
     # Gets all elements from the dictionary list.
-    # 
+    #
     # @method dict_info_list_elements(list)
     # @scope  class
     # @param  [FFI::Pointer] list A list of dictionaries as returned
     #  by {FFI::Aspell.dict_info_list}.
-    # @return [FFI::Pointer] dictionary Returns an enumeration of 
+    # @return [FFI::Pointer] dictionary Returns an enumeration of
     #  {FFI::Aspell::DictInfo} structs.
     #
     attach_function 'dict_info_list_elements',
@@ -286,7 +303,7 @@ module FFI
 
     ##
     # Deletes an enumeration of dictionaries.
-    # 
+    #
     # @method delete_dict_info_enumeration(enumeration)
     # @scope  class
     # @param  [FFI::Pointer] enumeration An enumeration of dictionaries returned
@@ -299,7 +316,7 @@ module FFI
 
     ##
     # Retrieves the next element in the list of dictionaries.
-    # 
+    #
     # @method dict_info_enumeration_next(elements)
     # @scope  class
     # @param  [FFI::Pointer] elements Pointer to a dictionary enumeration as returned


### PR DESCRIPTION
Allows installation on Darwin

* Previously would fail on OSX as it could not find the library:
    ```
    /opt/boxen/rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/ffi-1.9.18/lib/ffi/library.rb:147:in `block in ffi_lib': Could not open library 'libaspell.dylib': dlopen(libaspell.dylib, 5): image not found (LoadError)
    ```
* Add logic to check for common homebrew paths
* Also adds an environmental variable, allowing
workarounds for Windows users for example
* Fixes #26
* Updates instructions for `aspell` on brew
* Syntax has changed (https://github.com/Homebrew/legacy-homebrew/issues/23271)