### PR TITLE
Adds `libaspell` filename to array

### DIFF
--- a/lib/ffi/aspell/aspell.rb
+++ b/lib/ffi/aspell/aspell.rb
@@ -14,7 +14,7 @@ module FFI
   #
   module Aspell
     extend   FFI::Library
-    ffi_lib ['aspell', 'libaspell.so.15']
+    ffi_lib ['aspell', 'libaspell.so.15', 'libaspell']
 
     ##
     # Structure for storing dictionary information.


### PR DESCRIPTION
* Filename on OSX is `libaspell.dyld`, so the name
has to be added as `libaspell` so it is searched
when looking for the library:

```
Could not open library 'aspell': dlopen(aspell, 5): image not found. (LoadError)
Could not open library 'libaspell.dylib': dlopen(libaspell.dylib, 5): image not found.
Could not open library 'libaspell.so.15': dlopen(libaspell.so.15, 5): image not found.
Could not open library 'libaspell.so.15.dylib': dlopen(libaspell.so.15.dylib, 5): image not found.
Could not open library 'libaspell': dlopen(libaspell, 5): image not found
```

Note: This doesn't fix #26 for me because of the pathing issue with brew still, but it will look for that file now.